### PR TITLE
Less computationally expensive network

### DIFF
--- a/_modules/CNN_chocolate.py
+++ b/_modules/CNN_chocolate.py
@@ -1,36 +1,52 @@
 import torch.nn.functional as F
 import torch.nn as nn
-import params as p
 import torch
-import numpy as np
+
 
 class ConvNet(nn.Module):
     # This defines the structure of the NN.
     def __init__(self):
         super(ConvNet, self).__init__()
-        self.conv = nn.Conv2d(in_channels=1, out_channels=p.ch_out1, kernel_size=(3, p.k_w), stride=(1, p.s_w))
-        self.bn1 = nn.BatchNorm2d(p.ch_out1, True)
+        self.conv = nn.Conv2d(in_channels=1,
+                              out_channels=8,
+                              kernel_size=(3, 256),
+                              stride=(1, 128))
+        self.bn1 = nn.BatchNorm2d(8)
 
-        self.conv2 = nn.Conv2d(in_channels=p.ch_out1, out_channels=1, kernel_size=(1, 1), stride=(1, 1))
-        self.bn2 = nn.BatchNorm2d(1, False)
+        self.conv2 = nn.Conv2d(in_channels=8,
+                               out_channels=32,
+                               kernel_size=(5, 5),
+                               stride=(2, 2),
+                               groups=8)
+        self.bn2 = nn.BatchNorm2d(32)
+
+        self.conv3 = nn.Conv2d(in_channels=32,
+                               out_channels=64,
+                               kernel_size=(5, 5),
+                               stride=(1, 1),
+                               groups=32)
+        self.bn3 = nn.BatchNorm2d(64)
         
-        self.avgpool = nn.AvgPool2d(kernel_size=(1, 6))
-        #self.linear = nn.Linear(6,1)
-        #self.linear.bias.data.fill_(torch.log(torch.from_numpy(np.array(1/p.pos_weight))))
+        self.avgpool = nn.AvgPool2d(kernel_size=(25, 4))
 
+        self.lin = nn.Linear(64, 62)
+    
     def forward(self, x):
+        bs = x.shape[0]
         x = F.pad(x, (0, 0, 1, 1), mode='replicate')
+        
         x = self.conv(x)
         x = F.relu(x)
         x = self.bn1(x)
-        x = F.dropout(x, p.dp_rate)
 
         x = self.conv2(x)
         x = self.bn2(x)
-        x = F.dropout(x, p.dp_rate)
 
-        x = self.avgpool(x)
-        #x = self.linear(x)
-        x = x[0,0,:,0]
+        x = self.conv3(x)
+        x = self.bn3(x)
+
+        x = self.avgpool(x).view(bs, 64)
+
+        x = self.lin(x)
 
         return x


### PR DESCRIPTION
maybe this fits on MCU?

=====================================================================================================================================================================
Layer (type:depth-idx)                   Input Shape               Output Shape              Param #                   Kernel Shape              Mult-Adds
=====================================================================================================================================================================
ConvNet                                  --                        --                        --                        --                        --
├─Conv2d: 1-1                            [1, 1, 64, 2560]          [1, 8, 62, 19]            6,152                     [1, 8, 3, 256]            7,247,056
├─BatchNorm2d: 1-2                       [1, 8, 62, 19]            [1, 8, 62, 19]            16                        [8]                       16
├─Conv2d: 1-3                            [1, 8, 62, 19]            [1, 32, 29, 8]            832                       [1, 32, 5, 5]             193,024
├─BatchNorm2d: 1-4                       [1, 32, 29, 8]            [1, 32, 29, 8]            64                        [32]                      64
├─Conv2d: 1-5                            [1, 32, 29, 8]            [1, 64, 25, 4]            1,664                     [1, 64, 5, 5]             166,400
├─BatchNorm2d: 1-6                       [1, 64, 25, 4]            [1, 64, 25, 4]            128                       [64]                      128
├─AvgPool2d: 1-7                         [1, 64, 25, 4]            [1, 64, 1, 1]             --                        --                        --
├─Linear: 1-8                            [1, 64]                   [1, 62]                   4,030                     [64, 62]                  4,030
=====================================================================================================================================================================
Total params: 12,886
Trainable params: 12,886
Non-trainable params: 0
Total mult-adds (M): 7.61
=====================================================================================================================================================================
Input size (MB): 0.63
Forward/backward pass size (MB): 0.37
Params size (MB): 0.05
Estimated Total Size (MB): 1.06
=====================================================================================================================================================================